### PR TITLE
Allow a function (named "onTouchEnd") call on the end of touch.

### DIFF
--- a/patternLock.js
+++ b/patternLock.js
@@ -86,6 +86,7 @@
             });
             $(document).one(touchEnd, function() {
                 endHandler.call(this, e, obj);
+				if(obj.onTouchEnd)obj.onTouchEnd();
             });
             //set pattern offset
             var wrap = iObj.holder.find('.patt-wrap'),


### PR DESCRIPTION
检测到中文      英语     专业译文需求，试试百度人工翻译

这样做是为了方便去执行一些其他操作，比如执行一个ajax请求

This is done to facilitate the implementation of some other operations,
such as the implementation of a Ajax request